### PR TITLE
fix recursive bug by refactoring transformWorkToStep to use javascript generators

### DIFF
--- a/plugins/parodos/src/components/Form/Form.tsx
+++ b/plugins/parodos/src/components/Form/Form.tsx
@@ -104,7 +104,7 @@ export function Form({
       {stepLess ? (
         children
       ) : (
-        <ButtonGroup className={styles.buttonContainer}>
+        <ButtonGroup className={styles.buttonContainer} variant="contained">
           <Button
             disabled={activeStep === 0}
             className={styles.previous}

--- a/plugins/parodos/src/components/Form/Templates/ArrayFieldTemplate.tsx
+++ b/plugins/parodos/src/components/Form/Templates/ArrayFieldTemplate.tsx
@@ -115,48 +115,50 @@ export default function ArrayFieldTemplate<
         className={styles.stepper}
       >
         {items &&
-          items.map(
-            (
-              { key, ...itemProps }: ArrayFieldTemplateItemType<T, S, F>,
-              index,
-            ) => {
-              return (
-                <Step key={key}>
-                  <StepLabel
-                    StepIconProps={{ icon: String.fromCharCode(65 + index) }}
-                    className={formStyles.stepLabel}
-                  >
-                    {uiOptions.title || itemProps.schema.title}
-                  </StepLabel>
-                  <StepContent key={key}>
-                    <>
-                      <ArrayFieldItemTemplate key={key} {...itemProps} />
-                      <ButtonGroup>
-                        <Button
-                          disabled={activeItem === 0}
-                          className={formStyles.previous}
-                          onClick={() =>
-                            setActiveItem(a => (activeItem === 0 ? 0 : a - 1))
-                          }
-                        >
-                          PREVIOUS
-                        </Button>
-                        <Button
-                          variant="contained"
-                          type="button"
-                          color="primary"
-                          onClick={handleNext}
-                          className={formStyles.next}
-                        >
-                          NEXT
-                        </Button>
-                      </ButtonGroup>
-                    </>
-                  </StepContent>
-                </Step>
-              );
-            },
-          )}
+          items
+            .filter(Boolean)
+            .map(
+              (
+                { key, ...itemProps }: ArrayFieldTemplateItemType<T, S, F>,
+                index,
+              ) => {
+                return (
+                  <Step key={key}>
+                    <StepLabel
+                      StepIconProps={{ icon: String.fromCharCode(65 + index) }}
+                      className={formStyles.stepLabel}
+                    >
+                      {uiOptions.title || itemProps.schema.title}
+                    </StepLabel>
+                    <StepContent key={key}>
+                      <>
+                        <ArrayFieldItemTemplate key={key} {...itemProps} />
+                        <ButtonGroup variant="contained">
+                          <Button
+                            disabled={activeItem === 0}
+                            className={formStyles.previous}
+                            onClick={() =>
+                              setActiveItem(a => (activeItem === 0 ? 0 : a - 1))
+                            }
+                          >
+                            PREVIOUS
+                          </Button>
+                          <Button
+                            variant="contained"
+                            type="button"
+                            color="primary"
+                            onClick={handleNext}
+                            className={formStyles.next}
+                          >
+                            NEXT
+                          </Button>
+                        </ButtonGroup>
+                      </>
+                    </StepContent>
+                  </Step>
+                );
+              },
+            )}
       </Stepper>
     </>
   );

--- a/plugins/parodos/src/components/Form/styles.ts
+++ b/plugins/parodos/src/components/Form/styles.ts
@@ -7,13 +7,7 @@ export const useStyles = makeStyles(theme => ({
     },
   },
   previous: {
-    border: `1px solid ${theme.palette.primary.main}`,
-    color: theme.palette.text.primary,
-    marginRight: theme.spacing(1),
     textTransform: 'uppercase',
-    '&:disabled': {
-      border: `1px solid ${theme.palette.text.disabled}`,
-    },
   },
   next: {
     paddingRight: theme.spacing(4),


### PR DESCRIPTION
I found a bug in the recursion where not all of the JSON returned from the server was getting transformed into form elements in the react-json-schema-form.

The best way I can think of solving this (besides the server maybe returning a simpler JSON) is to use javascript generator functions that have a unique suspend and resume quality that is ideal for this very complex model.

The form is complex as well with a nested stepper so for now, I think this is the best solution.

Below is a screenshot of the nested JSON and the correctly rendered form:

![img](https://user-images.githubusercontent.com/118328/228229168-c39bcc86-350d-45ac-81c7-369795892810.png)
