### PR TITLE
move initiallyLoaded into state

### DIFF
--- a/plugins/parodos/src/components/App.tsx
+++ b/plugins/parodos/src/components/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useStore } from '../stores/workflowStore/workflowStore';
 import { useBackendUrl } from './api/useBackendUrl';
 import { PluginRouter } from './PluginRouter';
@@ -13,7 +13,7 @@ export const App = () => {
   const setBaseUrl = useStore(state => state.setBaseUrl);
   const fetchProjects = useStore(state => state.fetchProjects);
   const fetchDefinitions = useStore(state => state.fetchDefinitions);
-  const [initiallyLoaded, setInitiallyLoaded] = useState(false);
+  const initiallyLoaded = useStore(state => state.initiallyLoaded);
   const { fetch } = useApi(fetchApiRef);
 
   useEffect(() => {
@@ -23,7 +23,6 @@ export const App = () => {
       // We do not pre-fetch notifications, let's do that on demand.
       // TODO: fetch unread notificaionts count and keep it updated to render te tip to the user.
       await Promise.all([fetchProjects(fetch), fetchDefinitions(fetch)]);
-      setInitiallyLoaded(true);
     }
 
     initialiseStore();

--- a/plugins/parodos/src/stores/slices/projectsSlice.ts
+++ b/plugins/parodos/src/stores/slices/projectsSlice.ts
@@ -13,6 +13,7 @@ export const createProjectsSlice: StateCreator<
 > = (set, get) => ({
   projectsLoading: true,
   projectsError: undefined,
+  initiallyLoaded: false,
   hasProjects() {
     return get().projects.length > 0;
   },
@@ -32,6 +33,9 @@ export const createProjectsSlice: StateCreator<
         unstable_batchedUpdates(() => {
           state.projects = projects;
           state.projectsLoading = false;
+          if (state.initiallyLoaded === false) {
+            state.initiallyLoaded = true;
+          }
         });
       });
     } catch (e) {

--- a/plugins/parodos/src/stores/types.ts
+++ b/plugins/parodos/src/stores/types.ts
@@ -37,6 +37,7 @@ export interface ProjectsSlice {
   addProject(project: Project): void;
   projectsLoading: boolean;
   projectsError: Error | undefined;
+  initiallyLoaded: boolean;
 }
 
 export type NotificationState = 'ALL' | 'UNREAD' | 'ARCHIVED';


### PR DESCRIPTION
Apologies if this is coming across as pedantic and this is not my intent but I am always conscious of things that might come back to haunt me.

1 additional re-render does not sound bad but these things can add up if we do not stay on top of them.

The point about projects being undefined causing a lot of change is totally right so this is as another solution.

I have moved `initiallyLoaded` into the state and it can be updated in a batch without the additional re-render

```ts
set(state => {
  unstable_batchedUpdates(() => {
    state.projects = projects;
    state.projectsLoading = false;
    if (state.initiallyLoaded === false) {
      state.initiallyLoaded = true;
    }
  });
  ```