### PR TITLE
FLPATH-330: Update the project status from the API

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -61,7 +61,7 @@ proxy:
     headers:
       Content-Type: 'application/json'
       accept: 'application/json'
-      # Authorization: ${PARODOS_AUTH_KEY}
+      Authorization: ${PARODOS_AUTH_KEY}
 
   '/parodos-notifications':
     target: 'http://localhost:8081/api/v1'
@@ -73,7 +73,7 @@ proxy:
     headers:
       Content-Type: 'application/json'
       accept: 'application/json'
-      # Authorization: ${PARODOS_NOTIFICATION_AUTH_KEY}
+      Authorization: ${PARODOS_NOTIFICATION_AUTH_KEY}
 
 # Reference documentation http://backstage.io/docs/features/techdocs/configuration
 # Note: After experimenting with basic setup, use CI/CD to generate docs

--- a/plugins/parodos/src/components/projectOverview/ProjectOverview.test.tsx
+++ b/plugins/parodos/src/components/projectOverview/ProjectOverview.test.tsx
@@ -53,7 +53,7 @@ describe('ProjectOverview', () => {
       // wait for re-render after receiving data
       await findByText('myProject');
       expect(
-        container.querySelector('td[value="In Progress"]'),
+        container.querySelector('td[value="In progress"]'),
       ).toBeInTheDocument();
     });
   });

--- a/plugins/parodos/src/components/projectOverview/ProjectOverview.tsx
+++ b/plugins/parodos/src/components/projectOverview/ProjectOverview.tsx
@@ -18,8 +18,8 @@ type ProjectFilters = ProjectStatus | 'all-projects';
 
 const projectFilterItems: { label: string; value: ProjectFilters }[] = [
   { label: 'All Projects', value: 'all-projects' },
-  { label: 'In Progress', value: 'in-progress' },
-  { label: 'On Boarded', value: 'on-boarded' },
+  { label: 'In Progress', value: 'IN_PROGRESS' },
+  { label: 'Completed', value: 'COMPLETED' },
 ];
 
 export const useStyles = makeStyles(theme => ({

--- a/plugins/parodos/src/models/project.ts
+++ b/plugins/parodos/src/models/project.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod';
 
 const projectStatus = z.union([
-  z.literal('in-progress'),
-  z.literal('on-boarded'),
+  z.literal('IN_PROGRESS'),
+  z.literal('PENDING'),
+  z.literal('REJECTED'),
+  z.literal('FAILED'),
+  z.literal('COMPLETED')
 ]);
 
 export type ProjectStatus = z.infer<typeof projectStatus>;
@@ -14,8 +17,7 @@ export const projectSchema = z.object({
   createDate: z.coerce.date(),
   modifyDate: z.coerce.date(),
   username: z.string().nullable(),
-  // TODO: I hate this default and the API should be returing this
-  status: projectStatus.default('in-progress'),
+  status: projectStatus.default('IN_PROGRESS').transform((value) => value.split('_').join(' ')),
 });
 
 export type Project = z.infer<typeof projectSchema>;

--- a/plugins/parodos/src/models/project.ts
+++ b/plugins/parodos/src/models/project.ts
@@ -5,7 +5,7 @@ const projectStatus = z.union([
   z.literal('PENDING'),
   z.literal('REJECTED'),
   z.literal('FAILED'),
-  z.literal('COMPLETED')
+  z.literal('COMPLETED'),
 ]);
 
 export type ProjectStatus = z.infer<typeof projectStatus>;
@@ -17,7 +17,9 @@ export const projectSchema = z.object({
   createDate: z.coerce.date(),
   modifyDate: z.coerce.date(),
   username: z.string().nullable(),
-  status: projectStatus.default('IN_PROGRESS').transform((value) => value.split('_').join(' ')),
+  status: projectStatus
+    .default('IN_PROGRESS')
+    .transform(value => value.split('_').join(' ')),
 });
 
 export type Project = z.infer<typeof projectSchema>;

--- a/plugins/parodos/src/stores/slices/projectsSlice.ts
+++ b/plugins/parodos/src/stores/slices/projectsSlice.ts
@@ -29,6 +29,8 @@ export const createProjectsSlice: StateCreator<
 
       const projects = projectsResponse.map(projectSchema.parse) as Project[];
 
+      // projectStatus.split('-').map(capitalize).join(' ')
+
       set(state => {
         unstable_batchedUpdates(() => {
           state.projects = projects;

--- a/plugins/parodos/src/utils/string.ts
+++ b/plugins/parodos/src/utils/string.ts
@@ -1,5 +1,3 @@
-import { type ProjectStatus } from '../models/project';
-
 function capitalize(text: string): string {
   return `${text.charAt(0).toUpperCase()}${text.slice(1).toLowerCase()}`;
 }
@@ -12,7 +10,7 @@ function taskDisplayName(taskName: string): string {
     .join(' ');
 }
 
-export function projectStatusDisplayName(projectStatus: ProjectStatus): string {
+export function projectStatusDisplayName(projectStatus: string): string {
   return projectStatus.split('-').map(capitalize).join(' ');
 }
 


### PR DESCRIPTION
Provide a quick fix as a continuation of [FLPATH-285](https://issues.redhat.com/browse/FLPATH-285) to dynamically update project given the current project and workflow execution mapping from the UI
<img width="1486" alt="Screenshot 2023-04-21 at 3 27 46 PM" src="https://user-images.githubusercontent.com/15964569/233720287-a67aff06-c7e6-4465-9f34-7cc0cc71b843.png">
<img width="1490" alt="Screenshot 2023-04-21 at 3 29 28 PM" src="https://user-images.githubusercontent.com/15964569/233720306-54a86233-7fd7-4d0b-822c-fbd8054b299a.png">
<img width="1485" alt="Screenshot 2023-04-21 at 3 29 42 PM" src="https://user-images.githubusercontent.com/15964569/233720322-7f62caa6-6423-4d22-b82c-07617b021946.png">
