### PR TITLE
stop hot reloading appending to the state

### DIFF
--- a/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema/useWorkflowDefinitionToJsonSchema.ts
+++ b/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema/useWorkflowDefinitionToJsonSchema.ts
@@ -14,23 +14,29 @@ type Actions = {
   payload: { definition: WorkflowDefinition };
 };
 
-type State = { formSchema: FormSchema };
+type State = { formSchema: FormSchema; initialized: boolean };
 
 const reducer = (draft: State, action: Actions) => {
   // eslint-disable-next-line default-case
   switch (action.type) {
     case 'INITIALIZE': {
-      draft.formSchema = jsonSchemaFromWorkflowDefinition(
-        action.payload.definition,
-        draft.formSchema,
-      );
+      if (!draft.initialized) {
+        draft.formSchema = jsonSchemaFromWorkflowDefinition(
+          action.payload.definition,
+          draft.formSchema,
+        );
+
+        draft.initialized = true;
+      }
+
       break;
     }
   }
 };
 
-const initialState = {
+const initialState: State = {
   formSchema: { steps: [] },
+  initialized: false,
 };
 
 export function useWorkflowDefinitionToJsonSchema(


### PR DESCRIPTION
Hot reloading is causing the state to get appended on each hot reload.

This PR adds a basic check to ensure that the state is only initialized once