### PR TITLE
only update projects if something has changed

### DIFF
--- a/plugins/parodos/src/stores/slices/projectsSlice.ts
+++ b/plugins/parodos/src/stores/slices/projectsSlice.ts
@@ -29,6 +29,15 @@ export const createProjectsSlice: StateCreator<
 
       const projects = projectsResponse.map(projectSchema.parse) as Project[];
 
+      const existing = get()
+        .projects.map(p => p.id)
+        .sort();
+      const newProjects = projects.map(p => p.id).sort();
+
+      if (JSON.stringify(existing) === JSON.stringify(newProjects)) {
+        return;
+      }
+
       set(state => {
         unstable_batchedUpdates(() => {
           state.projects = projects;


### PR DESCRIPTION
The `useInterval` in App is causing a constant re-render on the projects overview page.

This stops the constant re-rendering unless something has changed.