### PR TITLE
Fix broken onboarding links

### DIFF
--- a/plugins/parodos/src/components/projectOverview/EmptyProjectsState.tsx
+++ b/plugins/parodos/src/components/projectOverview/EmptyProjectsState.tsx
@@ -28,7 +28,7 @@ export const EmptyProjectsState = () => {
         assessment.
       </Typography>
       <Typography paragraph>
-        <Link to="/parodos/workflows/new">GET STARTED</Link>
+        <Link to="/parodos/onboarding">GET STARTED</Link>
       </Typography>
     </Box>
   );

--- a/plugins/parodos/src/components/projectOverview/ProjectOverview.test.tsx
+++ b/plugins/parodos/src/components/projectOverview/ProjectOverview.test.tsx
@@ -47,7 +47,7 @@ describe('ProjectOverview', () => {
       expect(getByTestId('button-add-new-project')).toBeEnabled();
       expect(getByTestId('button-add-new-project')).toHaveAttribute(
         'href',
-        '/parodos/workflows/new',
+        '/parodos/onboarding',
       );
 
       // wait for re-render after receiving data

--- a/plugins/parodos/src/components/projectOverview/ProjectOverview.tsx
+++ b/plugins/parodos/src/components/projectOverview/ProjectOverview.tsx
@@ -97,7 +97,7 @@ export const ProjectOverviewPage = (): JSX.Element => {
 
             <Grid item xs={12} md={8} lg={10}>
               <Link
-                to="/parodos/workflows/new"
+                to="/parodos/onboarding"
                 className={styles.addIcon}
                 data-testid="button-add-new-project"
               >

--- a/plugins/parodos/src/components/workflow/WorkflowsOverview.tsx
+++ b/plugins/parodos/src/components/workflow/WorkflowsOverview.tsx
@@ -98,7 +98,7 @@ export function WorkflowsOverview(): JSX.Element {
             variant="contained"
             type="button"
             color="primary"
-            onClick={() => navigate(`${pluginRoutePrefix}/workflows/new`)}
+            onClick={() => navigate(`${pluginRoutePrefix}/onboarding`)}
           >
             Add new project
           </Button>


### PR DESCRIPTION
In the previous PR #124 I broke links to onboarding screen, because of renaming some links