### PR TITLE
don't create Step if work has no parameters and all works are workType WORKFLOW

### DIFF
--- a/plugins/parodos/src/components/workflow/hooks/worksPayload.test.ts
+++ b/plugins/parodos/src/components/workflow/hooks/worksPayload.test.ts
@@ -1,56 +1,98 @@
 import { type StrictRJSFSchema } from '@rjsf/utils';
+import { mockTasksWithNoParams } from '../../../mocks/workflowDefinitions/tasksWithNoParameters';
 import { WorkflowDefinition } from '../../../models/workflowDefinitionSchema';
 import { getWorklfowsPayload } from './workflowsPayload';
 
-const mockMasterWorkFlow: WorkflowDefinition = {
-  id: '2dfbb023-bf5e-426d-ad6c-451f77e73d25',
-  name: 'masterWorkFlow',
-  type: 'INFRASTRUCTURE',
-  processingType: 'SEQUENTIAL',
-  author: null,
-  createDate: '2023-03-30T15:16:54.406+00:00',
-  modifyDate: '2023-03-30T15:16:54.406+00:00',
-  parameters: {
-    projectUrl: {
-      description: 'The project url',
-      required: false,
-      type: 'string',
-      format: 'url',
-    },
-    workloadId: {
-      description: 'The workload id',
-      required: true,
-      type: 'string',
-      format: 'text',
-    },
-  },
-  // TODO: flesh out for better test
-  works: [],
-};
-
-const mockFormData = {
-  masterWorkFlow: {
-    projectUrl: 'https://g.com',
-    workloadId: 'dfds',
-  },
-};
-
-describe('works payload', () => {
-  it('should transform formData to wworks payload', () => {
-    const result = getWorklfowsPayload({
-      projectId: '10',
-      workflow: mockMasterWorkFlow,
-      schema: mockFormData as StrictRJSFSchema,
-    });
-
-    expect(result).toEqual({
-      projectId: '10',
-      workFlowName: 'masterWorkFlow',
-      arguments: [
-        { key: 'projectUrl', value: 'https://g.com' },
-        { key: 'workloadId', value: 'dfds' },
-      ],
+describe('getWorksPayload', () => {
+  describe('simple', () => {
+    const mockMasterWorkFlow: WorkflowDefinition = {
+      id: '2dfbb023-bf5e-426d-ad6c-451f77e73d25',
+      name: 'masterWorkFlow',
+      type: 'INFRASTRUCTURE',
+      processingType: 'SEQUENTIAL',
+      author: null,
+      createDate: '2023-03-30T15:16:54.406+00:00',
+      modifyDate: '2023-03-30T15:16:54.406+00:00',
+      parameters: {
+        projectUrl: {
+          description: 'The project url',
+          required: false,
+          type: 'string',
+          format: 'url',
+        },
+        workloadId: {
+          description: 'The workload id',
+          required: true,
+          type: 'string',
+          format: 'text',
+        },
+      },
+      // TODO: flesh out for better test
       works: [],
+    };
+
+    const mockFormData = {
+      masterWorkFlow: {
+        projectUrl: 'https://g.com',
+        workloadId: 'dfds',
+      },
+    };
+
+    it('should transform formData to works payload', () => {
+      const result = getWorklfowsPayload({
+        projectId: '10',
+        workflow: mockMasterWorkFlow,
+        schema: mockFormData as StrictRJSFSchema,
+      });
+
+      expect(result).toEqual({
+        projectId: '10',
+        workFlowName: 'masterWorkFlow',
+        arguments: [
+          { key: 'projectUrl', value: 'https://g.com' },
+          { key: 'workloadId', value: 'dfds' },
+        ],
+        works: [],
+      });
+    });
+  });
+
+  describe('few UI elements', () => {
+    const schema = {
+      getSources: {
+        works: [
+          {
+            gitCloneTask: {
+              credentials: 'git',
+              uri: 'https://github.com/eloycoto/spring-helloworld.git',
+              branch: 'main',
+            },
+          },
+        ],
+      },
+    };
+
+    it('should work with deeply nested schema', () => {
+      const result = getWorklfowsPayload({
+        projectId: '111',
+        workflow: mockTasksWithNoParams,
+        schema: schema as StrictRJSFSchema,
+      });
+
+      expect(result.works?.[0]?.works?.[0]?.works?.[0]?.arguments).toEqual([
+        {
+          key: 'credentials',
+          value: 'git',
+        },
+        {
+          key: 'uri',
+          value: 'https://github.com/eloycoto/spring-helloworld.git',
+        },
+        {
+          key: 'branch',
+          value: 'main',
+        },
+      ]);
     });
   });
 });

--- a/plugins/parodos/src/components/workflow/onboarding/Onboarding.tsx
+++ b/plugins/parodos/src/components/workflow/onboarding/Onboarding.tsx
@@ -106,7 +106,7 @@ export function Onboarding({ isNew }: OnboardingProps): JSX.Element {
               variant="text"
               component={Link}
               color="primary"
-              to="/parodos/project-overview"
+              to="/parodos/workflows"
               className={styles.cancel}
             >
               Cancel and exit onboarding

--- a/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema/jsonSchemaFromWorkflowDefinition.test.ts
+++ b/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema/jsonSchemaFromWorkflowDefinition.test.ts
@@ -6,6 +6,7 @@ import {
   WorkType,
 } from '../../models/workflowDefinitionSchema';
 import { mockDeepRecursiveWorks } from '../../mocks/workflowDefinitions/deepRecursiveWorks';
+import { mockTasksWithNoParams } from '../../mocks/workflowDefinitions/tasksWithNoParameters';
 
 describe('jsonSchemaFromWorkflowDefinition', () => {
   it('transforms a workflow definition with recursive works', () => {
@@ -80,5 +81,20 @@ describe('jsonSchemaFromWorkflowDefinition', () => {
     );
 
     expect(valueProviderName).toBe('complexWorkFlowValueProvider');
+  });
+
+  it('work items with no parameters and every child works has workType WORKFLOW', () => {
+    const result = jsonSchemaFromWorkflowDefinition(mockTasksWithNoParams, {
+      steps: [],
+    });
+
+    expect(result.steps).toHaveLength(1);
+
+    const stepUI = get(
+      result.steps[0]?.schema,
+      'properties.getSources.properties.works.items[0].properties.gitCloneTask.properties',
+    );
+
+    expect(Object.keys(stepUI ?? {})).toEqual(['credentials', 'uri', 'branch']);
   });
 });

--- a/plugins/parodos/src/mocks/workflowDefinitions/tasksWithNoParameters.ts
+++ b/plugins/parodos/src/mocks/workflowDefinitions/tasksWithNoParameters.ts
@@ -1,0 +1,86 @@
+import { WorkflowDefinition } from '../../models/workflowDefinitionSchema';
+
+export const mockTasksWithNoParams: WorkflowDefinition = {
+  id: 'de309484-f24e-43bb-992a-4f9306381b27',
+  name: 'move2KubeWorkFlow_INFRASTRUCTURE_WORKFLOW',
+  type: 'INFRASTRUCTURE',
+  processingType: 'SEQUENTIAL',
+  author: null,
+  createDate: '2023-05-14T20:11:40.310+00:00',
+  modifyDate: '2023-05-14T20:11:40.310+00:00',
+  // properties: {
+  //   version: null
+  // },
+  works: [
+    {
+      id: '115e2976-c4be-4ec0-bb09-06a3a2d1231f',
+      name: 'preparationWorkflow',
+      workType: 'WORKFLOW',
+      processingType: 'PARALLEL',
+      works: [
+        {
+          id: '431606c3-33ce-46ec-8742-2e76b7bb5753',
+          name: 'getSources',
+          workType: 'WORKFLOW',
+          processingType: 'SEQUENTIAL',
+          works: [
+            {
+              id: 'a7ec1d2b-beac-43ed-aacf-91b0f159c2e9',
+              name: 'gitCloneTask',
+              workType: 'TASK',
+              parameters: {
+                credentials: {
+                  format: 'text',
+                  description: 'Git credential',
+                  type: 'string',
+                  required: true,
+                },
+                uri: {
+                  format: 'text',
+                  description: 'Url to clone from',
+                  type: 'string',
+                  required: true,
+                },
+                branch: {
+                  format: 'text',
+                  description: 'Branch to clone from, default main',
+                  type: 'string',
+                  required: false,
+                },
+              },
+            },
+            {
+              id: 'ebaa5066-bff1-4103-89dd-ef125b314893',
+              name: 'gitArchiveTask',
+              workType: 'TASK',
+            },
+          ],
+        },
+        {
+          id: 'ecf4b510-9e4d-4e08-9338-d371d3b40959',
+          name: 'move2KubeProject',
+          workType: 'WORKFLOW',
+          processingType: 'SEQUENTIAL',
+          works: [
+            {
+              id: '950941ed-e753-4990-915d-e4c34bdffbf9',
+              name: 'move2KubeTask',
+              workType: 'TASK',
+              outputs: ['HTTP2XX', 'OTHER'],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'e8262676-350e-4480-a987-d082cfc2737d',
+      name: 'move2KubePlan',
+      workType: 'TASK',
+    },
+    {
+      id: '59712f15-97a6-42fd-acc1-a05855e4c215',
+      name: 'move2KubeTransform',
+      workType: 'TASK',
+    },
+  ],
+};


### PR DESCRIPTION
There is a situation where a work item has no parameters and only has child work items of workType `WORKFLOW`.

The UI was rendering a step with no UI elements that could not validate.

This PR skips rendering steps with no UI elements.