### PR TITLE
assert app-config workflows configuration

### DIFF
--- a/plugins/parodos/src/components/App.tsx
+++ b/plugins/parodos/src/components/App.tsx
@@ -18,7 +18,7 @@ export const App = () => {
   const { initialStateLoaded } = useInitializeStore();
 
   useEffect(() => {
-    if(!projectError) {
+    if (!projectError) {
       return;
     }
 
@@ -26,7 +26,7 @@ export const App = () => {
     console.error(projectError);
 
     errorApi.post(new Error(`Internal server error.`));
-  }, [errorApi, projectError])
+  }, [errorApi, projectError]);
 
   useInterval(() => {
     if (!initialStateLoaded) {

--- a/plugins/parodos/src/components/App.tsx
+++ b/plugins/parodos/src/components/App.tsx
@@ -1,19 +1,32 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useInterval } from '@patternfly/react-core';
 import { Progress } from '@backstage/core-components';
 
 import { useStore } from '../stores/workflowStore/workflowStore';
 import { useInitializeStore } from '../hooks/useInitializeStore';
 import { PluginRouter } from './PluginRouter';
-import { fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { errorApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 
 const POLLING_INTERVAL_MILLISECONDS = 5 * 1000;
 
 export const App = () => {
   const fetchProjects = useStore(state => state.fetchProjects);
   const { fetch } = useApi(fetchApiRef);
+  const errorApi = useApi(errorApiRef);
+  const projectError = useStore(state => state.projectsError);
 
   const { initialStateLoaded } = useInitializeStore();
+
+  useEffect(() => {
+    if(!projectError) {
+      return;
+    }
+
+    // eslint-disable-next-line no-console
+    console.error(projectError);
+
+    errorApi.post(new Error(`Internal server error.`));
+  }, [errorApi, projectError])
 
   useInterval(() => {
     if (!initialStateLoaded) {

--- a/plugins/parodos/src/hooks/useInitializeStore.ts
+++ b/plugins/parodos/src/hooks/useInitializeStore.ts
@@ -12,9 +12,7 @@ export const useInitializeStore = () => {
   const initialized = useStore(state => state.initialized());
   const { fetch } = useApi(fetchApiRef);
   const workflowDefinitions = useStore(state => state.workflowDefinitions);
-  const getWorkDefinitionBy = useStore(state =>
-    state.getWorkDefinitionBy,
-  );
+  const getWorkDefinitionBy = useStore(state => state.getWorkDefinitionBy);
 
   useEffect(() => {
     setAppConfig(appConfig);
@@ -26,9 +24,8 @@ export const useInitializeStore = () => {
     initialiseStore();
   }, [appConfig, fetch, fetchDefinitions, fetchProjects, setAppConfig]);
 
-
   useEffect(() => {
-    if(workflowDefinitions.length === 0) {
+    if (workflowDefinitions.length === 0) {
       return;
     }
 
@@ -36,12 +33,20 @@ export const useInitializeStore = () => {
 
     const assessmentWorkflow = getWorkDefinitionBy('byName', assessment);
 
-    assert(!!assessmentWorkflow, `invalid workflow config for assessment ${assessment}`);
-    
-    const assessmentWorkflowTask = assessmentWorkflow?.works.find(w => w.name === assessmentTask);
-    
-    assert(!!assessmentWorkflowTask, `no assessment task named ${assessmentTask} found in ${assessment} works array`);
-  }, [appConfig.workflows, getWorkDefinitionBy, workflowDefinitions])
+    assert(
+      !!assessmentWorkflow,
+      `invalid workflow config for assessment ${assessment}`,
+    );
+
+    const assessmentWorkflowTask = assessmentWorkflow?.works.find(
+      w => w.name === assessmentTask,
+    );
+
+    assert(
+      !!assessmentWorkflowTask,
+      `no assessment task named ${assessmentTask} found in ${assessment} works array`,
+    );
+  }, [appConfig.workflows, getWorkDefinitionBy, workflowDefinitions]);
 
   return {
     initialStateLoaded: initialized,


### PR DESCRIPTION
This PR adds assertions to check that the app-config for workflows points to an actual definition and a task:

```yaml
parodos:
  workflows:
    assessment: 'onboardingAssessment_ASSESSMENT_WORKFLOW'
    assessmentTask: 'onboardingAssessmentTask'
```

I've also added an indicator to the user if the API goes down.