### PR TITLE
remove onChange handler in assessment form

### DIFF
--- a/plugins/parodos/src/components/Form/Form.tsx
+++ b/plugins/parodos/src/components/Form/Form.tsx
@@ -34,6 +34,7 @@ type FormProps = Pick<
     stepLess?: boolean;
     children?: ReactNode;
     updateSchema?: UpdateSchemaAction;
+    finalSubmitButtonText?: string;
   };
 
 export function Form({
@@ -47,6 +48,7 @@ export function Form({
   updateSchema,
   hideTitle = false,
   stepLess = false,
+  finalSubmitButtonText = 'NEXT',
   children,
   ...props
 }: FormProps): JSX.Element {
@@ -56,6 +58,8 @@ export function Form({
   const formRef = useRef<CoreForm>(null);
 
   const currentStep = formSchema.steps[activeStep];
+
+  const isLastStep = activeStep === formSchema.steps.length - 1;
 
   const handleBack = () => {
     setActiveStep(prevActiveStep => prevActiveStep - 1);
@@ -129,7 +133,7 @@ export function Form({
             className={styles.next}
             disabled={disabled}
           >
-            NEXT
+            {isLastStep ? finalSubmitButtonText : 'NEXT'}
           </Button>
         </ButtonGroup>
       )}

--- a/plugins/parodos/src/components/workflow/Workflow.tsx
+++ b/plugins/parodos/src/components/workflow/Workflow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   ContentHeader,
   InfoCard,
@@ -7,7 +7,7 @@ import {
 import { errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { Form } from '../Form/Form';
 import { ParodosPage } from '../ParodosPage';
-import { Button, Grid, makeStyles, Typography } from '@material-ui/core';
+import { Grid, makeStyles, Typography } from '@material-ui/core';
 import { useGetProjectAssessmentSchema } from './useGetProjectAssessmentSchema';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 import { IChangeEvent } from '@rjsf/core-v5';
@@ -84,20 +84,6 @@ export function Workflow(): JSX.Element {
     }
   }, [createWorkflowError, errorApi, startAssessmentError]);
 
-  const changeHandler = useCallback(
-    async (e: IChangeEvent<Record<string, ProjectsPayload>>) => {
-      if (!e.formData?.[assessmentTask]) {
-        return;
-      }
-
-      await createWorkflow({
-        workflowProject: selectedProject,
-        formData: e.formData,
-      });
-    },
-    [assessmentTask, createWorkflow, selectedProject],
-  );
-
   const inProgress = assessmentStatus === 'inprogress';
   const complete = assessmentStatus === 'complete';
 
@@ -122,17 +108,10 @@ export function Workflow(): JSX.Element {
                 formSchema={formSchema}
                 onSubmit={startAssessment}
                 disabled={disableForm}
-                onChange={changeHandler}
-              >
-                <Button
-                  type="submit"
-                  disabled={disableForm ?? inProgress}
-                  variant="contained"
-                  color="primary"
-                >
-                  {inProgress ? 'IN PROGRESS' : 'START ASSESSMENT'}
-                </Button>
-              </Form>
+                finalSubmitButtonText={
+                  inProgress ? 'IN PROGRESS' : 'START ASSESSMENT'
+                }
+              />
             </Grid>
             <Grid item xs={12}>
               {displayOptions && (


### PR DESCRIPTION
The assessment workflow form has a change handler that should have been removed in #145 and is now calling the API on each input change 🤦 .

This PR rights that wrong.