### PR TITLE
WIP: Update services paths

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -53,7 +53,7 @@ integrations:
 
 proxy:
   '/parodos':
-    target: 'http://localhost:8080/api/v1'
+    target: 'http://localhost:8080/workflow-service/api/v1'
     changeOrigin: true
     redirect: follow
     cache: 'no-cache'
@@ -64,7 +64,7 @@ proxy:
       accept: 'application/json'
 
   '/parodos-notifications':
-    target: 'http://localhost:8081/api/v1'
+    target: 'http://localhost:8081/notification-service/api/v1'
     changeOrigin: true
     redirect: follow
     cache: 'no-cache'


### PR DESCRIPTION
To reflect changes made in `parodos` PR https://github.com/parodos-dev/parodos/pull/376

When deploying `parodos` in a `Kind` cluster using `kubectl kustomize hack/manifests/testing | kubectl apply -f -` the workflow service and the notification service paths have been changed.

Depends on PR https://github.com/parodos-dev/parodos/pull/376