### PR TITLE
don't display logs for inactive taks

### DIFF
--- a/plugins/parodos/src/components/workflow/workflowDetail/topology/PipelineLayout.tsx
+++ b/plugins/parodos/src/components/workflow/workflowDetail/topology/PipelineLayout.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useRef, useState } from 'react';
+import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import {
   DEFAULT_EDGE_TYPE,
   DEFAULT_FINALLY_NODE_TYPE,
@@ -23,6 +23,7 @@ import pipelineComponentFactory from './pipelineComponentFactory';
 import { useDemoPipelineNodes } from './useDemoPipelineNodes';
 import { WorkflowTask } from '../../../../models/workflowTaskSchema';
 import { useParentSize } from '@cutting/use-get-parent-size';
+import { assert } from 'assert-ts';
 
 export const PIPELINE_NODE_SEPARATION_VERTICAL = 10;
 
@@ -33,9 +34,9 @@ type Props = {
   setSelectedTask: (selectedTask: string) => void;
 };
 
-const TopologyPipelineLayout = (props: Props) => {
+const TopologyPipelineLayout = ({ tasks, setSelectedTask }: Props) => {
   const [selectedIds, setSelectedIds] = useState<string[]>();
-  const pipelineNodes = useDemoPipelineNodes(props.tasks);
+  const pipelineNodes = useDemoPipelineNodes(tasks);
   const controller = useVisualizationController();
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -72,11 +73,19 @@ const TopologyPipelineLayout = (props: Props) => {
       },
       true,
     );
-  }, [controller, pipelineNodes, props.tasks]);
+  }, [controller, pipelineNodes]);
 
-  useEventListener<SelectionEventListener>(SELECTION_EVENT, ids => {
-    setSelectedIds(ids);
-    props.setSelectedTask(ids.toString());
+  useEventListener<SelectionEventListener>(SELECTION_EVENT, ([taskId]) => {
+    const selected = tasks.find(task => task.id === taskId);
+
+    assert(!!selected, `no selected task for ${taskId}`);
+
+    if (taskId === 'Start' || selected.status === 'PENDING') {
+      return;
+    }
+
+    setSelectedIds([taskId]);
+    setSelectedTask(taskId);
   });
 
   return (
@@ -91,7 +100,7 @@ const TopologyPipelineLayout = (props: Props) => {
 TopologyPipelineLayout.displayName = 'TopologyPipelineLayout';
 
 export const PipelineLayout = memo((props: Props) => {
-  const controller = new Visualization();
+  const controller = useMemo(() => new Visualization(), []);
   controller.setFitToScreenOnLayout(true);
   controller.registerComponentFactory(pipelineComponentFactory);
   controller.registerLayoutFactory(

--- a/plugins/parodos/src/components/workflow/workflowDetail/topology/PipelineLayout.tsx
+++ b/plugins/parodos/src/components/workflow/workflowDetail/topology/PipelineLayout.tsx
@@ -24,6 +24,7 @@ import { useDemoPipelineNodes } from './useDemoPipelineNodes';
 import { WorkflowTask } from '../../../../models/workflowTaskSchema';
 import { useParentSize } from '@cutting/use-get-parent-size';
 import { assert } from 'assert-ts';
+import { FirstTaskId } from '../../../../hooks/getWorkflowDefinitions';
 
 export const PIPELINE_NODE_SEPARATION_VERTICAL = 10;
 
@@ -80,7 +81,7 @@ const TopologyPipelineLayout = ({ tasks, setSelectedTask }: Props) => {
 
     assert(!!selected, `no selected task for ${taskId}`);
 
-    if (taskId === 'Start' || selected.status === 'PENDING') {
+    if (taskId === FirstTaskId || selected.status === 'PENDING') {
       return;
     }
 

--- a/plugins/parodos/src/hooks/getWorkflowDefinitions.ts
+++ b/plugins/parodos/src/hooks/getWorkflowDefinitions.ts
@@ -11,10 +11,10 @@ export function getWorkflowTasksForTopology(
   const result: WorkflowTask[] = [];
 
   result.push({
-    id: 'Project Information',
+    id: 'Start',
     status: 'COMPLETED',
     locked: false,
-    label: 'Project Information',
+    label: 'Start',
     runAfterTasks: [],
   });
 

--- a/plugins/parodos/src/hooks/getWorkflowDefinitions.ts
+++ b/plugins/parodos/src/hooks/getWorkflowDefinitions.ts
@@ -5,13 +5,15 @@ import {
 import { taskDisplayName } from '../utils/string';
 import { WorkflowTask } from '../models/workflowTaskSchema';
 
+export const FirstTaskId = 'Start';
+
 export function getWorkflowTasksForTopology(
   workflowDefinition: WorkflowDefinition,
 ): WorkflowTask[] {
   const result: WorkflowTask[] = [];
 
   result.push({
-    id: 'Start',
+    id: FirstTaskId,
     status: 'COMPLETED',
     locked: false,
     label: 'Start',


### PR DESCRIPTION
The first task or a task that is pending will return a 404 with a call to `/logs`.

This PR stops does not call the API in those cases.