### PR TITLE
remove assessmentTask

### DIFF
--- a/plugins/parodos/config.d.ts
+++ b/plugins/parodos/config.d.ts
@@ -6,11 +6,6 @@ export interface Config {
        * @visibility frontend
        */
       assessment: string;
-      /**
-       * TODO: description
-       * @visibility frontend
-       */
-      assessmentTask: string;
     };
     /**
      * TODO: description

--- a/plugins/parodos/src/components/TestApp.tsx
+++ b/plugins/parodos/src/components/TestApp.tsx
@@ -23,7 +23,6 @@ export const TestApp: React.FC = ({ children }) => {
     parodos: {
       workflows: {
         assessment: 'onboardingAssessment_ASSESSMENT_WORKFLOW',
-        assessmentTask: 'onboardingAssessmentTask',
       },
       pollingInterval: 5000,
     },

--- a/plugins/parodos/src/components/api/useGetAppConfig.ts
+++ b/plugins/parodos/src/components/api/useGetAppConfig.ts
@@ -10,7 +10,6 @@ export const useGetAppConfig = (): ParodosConfig => {
       backendUrl: configApi.getString('backend.baseUrl'),
       workflows: {
         assessment: configApi.getString('parodos.workflows.assessment'),
-        assessmentTask: configApi.getString('parodos.workflows.assessmentTask'),
       },
       pollingInterval: configApi.getNumber('parodos.pollingInterval'),
     }),

--- a/plugins/parodos/src/components/workflow/Workflow.tsx
+++ b/plugins/parodos/src/components/workflow/Workflow.tsx
@@ -41,7 +41,6 @@ const useStyles = makeStyles(theme => ({
 
 export function Workflow(): JSX.Element {
   const assessment = useStore(state => state.workflows.assessment);
-  const assessmentTask = useStore(state => state.workflows.assessmentTask);
   const [searchParams] = useSearchParams();
   const selectedProject = useStore(state =>
     state.getProjectById(searchParams.get('project')),
@@ -58,7 +57,7 @@ export function Workflow(): JSX.Element {
   const formSchema = useGetProjectAssessmentSchema();
 
   const [{ error: createWorkflowError, loading: _ }, createWorkflow] =
-    useCreateWorkflow({ assessment, assessmentTask });
+    useCreateWorkflow({ assessment });
 
   const [{ error: startAssessmentError }, startAssessment] = useAsyncFn(
     async ({ formData }: IChangeEvent<Record<string, ProjectsPayload>>) => {

--- a/plugins/parodos/src/components/workflow/Workflow.tsx
+++ b/plugins/parodos/src/components/workflow/Workflow.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import {
   ContentHeader,
   InfoCard,
+  Progress,
   SupportButton,
 } from '@backstage/core-components';
 import { errorApiRef, useApi } from '@backstage/core-plugin-api';
@@ -66,7 +67,7 @@ export function Workflow(): JSX.Element {
       setAssessmentStatus('inprogress');
 
       setWorkflowOptions(
-        await createWorkflow({ workflowProject: selectedProject, formData }),
+        await createWorkflow({ project: selectedProject, formData }),
       );
 
       setAssessmentStatus('complete');
@@ -100,6 +101,7 @@ export function Workflow(): JSX.Element {
         Select a project for an assessment of what additional workflows, if any,
         it qualifies for.
       </Typography>
+      {inProgress && <Progress />}
       {formSchema && (
         <InfoCard className={styles.fullHeight}>
           <Grid container direction="row" className={styles.form}>

--- a/plugins/parodos/src/components/workflow/hooks/useCreateWorkflow.ts
+++ b/plugins/parodos/src/components/workflow/hooks/useCreateWorkflow.ts
@@ -23,12 +23,7 @@ export interface ProjectsPayload {
   project?: Project;
 }
 
-export function useCreateWorkflow({
-  assessment,
-}: {
-  assessment: string;
-  assessmentTask: string;
-}) {
+export function useCreateWorkflow({ assessment }: { assessment: string }) {
   const workflowsUrl = useStore(state => state.getApiUrl(urls.Workflows));
   const assessmentWorkflow = useStore(state =>
     state.getWorkDefinitionBy('byName', assessment),

--- a/plugins/parodos/src/hooks/useInitializeStore.ts
+++ b/plugins/parodos/src/hooks/useInitializeStore.ts
@@ -29,22 +29,13 @@ export const useInitializeStore = () => {
       return;
     }
 
-    const { assessment, assessmentTask } = appConfig.workflows;
+    const { assessment } = appConfig.workflows;
 
     const assessmentWorkflow = getWorkDefinitionBy('byName', assessment);
 
     assert(
       !!assessmentWorkflow,
       `invalid workflow config for assessment ${assessment}`,
-    );
-
-    const assessmentWorkflowTask = assessmentWorkflow?.works.find(
-      w => w.name === assessmentTask,
-    );
-
-    assert(
-      !!assessmentWorkflowTask,
-      `no assessment task named ${assessmentTask} found in ${assessment} works array`,
     );
   }, [appConfig.workflows, getWorkDefinitionBy, workflowDefinitions]);
 

--- a/plugins/parodos/src/stores/slices/uiSlice.ts
+++ b/plugins/parodos/src/stores/slices/uiSlice.ts
@@ -13,7 +13,6 @@ export const createUISlice: StateCreator<
   pollingInterval: 0,
   workflows: {
     assessment: '',
-    assessmentTask: '',
   },
   getApiUrl(url: string) {
     return `${get().baseUrl}${url}`;
@@ -23,7 +22,6 @@ export const createUISlice: StateCreator<
       unstable_batchedUpdates(() => {
         state.baseUrl = config.backendUrl;
         state.workflows.assessment = config.workflows.assessment;
-        state.workflows.assessmentTask = config.workflows.assessmentTask;
         state.pollingInterval = config.pollingInterval;
       }, false);
     });

--- a/plugins/parodos/src/types.tsx
+++ b/plugins/parodos/src/types.tsx
@@ -2,7 +2,6 @@ export interface ParodosConfig {
   backendUrl: string;
   workflows: {
     assessment: string;
-    assessmentTask: string;
   };
   pollingInterval: number;
 }


### PR DESCRIPTION
We no longer need the `assessmentTask` check now that the project and assessment workflow have been disassociated. 