### PR TITLE
remove assessmentTask config value from app-config.yaml

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -5,7 +5,6 @@ app:
 parodos:
   workflows:
     assessment: 'onboardingAssessment_ASSESSMENT_WORKFLOW'
-    assessmentTask: 'onboardingAssessmentTask'
   pollingInterval: 10000
 
 organization:


### PR DESCRIPTION
The `assessmentTask` config option is no longer needed.