### PR TITLE
fail assessment if workflow task's status is rejected

### DIFF
--- a/plugins/parodos/src/components/ParodosPage/Tabs.tsx
+++ b/plugins/parodos/src/components/ParodosPage/Tabs.tsx
@@ -49,7 +49,6 @@ export function Tabs(): JSX.Element {
                 <span {...tabProps} ref={ref}>
                   <NavLink to={`${pluginRoutePrefix}${route}`}>
                     {navigationMap[index].icon}
-                    {tabChildren}
                     {notifyIcon && (
                       <Badge
                         color="secondary"
@@ -59,6 +58,7 @@ export function Tabs(): JSX.Element {
                         <NotificationImportantIcon color="secondary" />
                       </Badge>
                     )}
+                    {tabChildren}
                   </NavLink>
                 </span>
               ),

--- a/plugins/parodos/src/components/workflow/Workflow.tsx
+++ b/plugins/parodos/src/components/workflow/Workflow.tsx
@@ -70,9 +70,16 @@ export function Workflow(): JSX.Element {
 
       setAssessmentStatus('inprogress');
 
-      setWorkflowOptions(
-        await createWorkflow({ project: selectedProject, formData }),
-      );
+      const options = await createWorkflow({
+        project: selectedProject,
+        formData,
+      });
+
+      if (!Array.isArray(options)) {
+        return;
+      }
+
+      setWorkflowOptions(options);
 
       setAssessmentStatus('complete');
     },

--- a/plugins/parodos/src/components/workflow/hooks/pollWorkflowStatus.ts
+++ b/plugins/parodos/src/components/workflow/hooks/pollWorkflowStatus.ts
@@ -39,6 +39,12 @@ export async function pollWorkflowStatus(
       break;
     }
 
+    if (workflowStatus.works.some(w => w.status === 'REJECTED')) {
+      throw new Error(
+        `A workflow task has been rejected.  Please check the logs for this task.`,
+      );
+    }
+
     const completed = workflowStatus.works.reduce(
       (acc, work) => (work.status === 'COMPLETED' ? acc + 1 : acc),
       0,
@@ -50,7 +56,7 @@ export async function pollWorkflowStatus(
 
     if (previousProgress >= progress) {
       if (previousProgress < 99) {
-        previousProgress = previousProgress + 0.5;
+        previousProgress = previousProgress + 0.1;
       }
     } else {
       previousProgress = progress;


### PR DESCRIPTION
There is a possible bug in the backend where a task's status is `REJECTED` but the overall status is `IN_PROGRESS`.

This PR stops polling the `/status` calls if a task's status is `REJECTED`.