### PR TITLE
Poll only unread notifications count

### DIFF
--- a/plugins/parodos/src/components/ParodosPage/Tabs.tsx
+++ b/plugins/parodos/src/components/ParodosPage/Tabs.tsx
@@ -12,15 +12,8 @@ export interface TabLabelProps {
 
 export function Tabs(): JSX.Element {
   const { pathname } = useLocation();
-  const notifications = useStore(state => state.notifications);
-
-  const unreadNotificaitons = useMemo(
-    () =>
-      [...notifications.values()].reduce(
-        (acc, n) => (!n.read ? acc + 1 : acc),
-        0,
-      ),
-    [notifications],
+  const unreadNotificationsCount = useStore(
+    state => state.unreadNotificationsCount,
   );
 
   const selectedTab = useMemo(
@@ -35,7 +28,8 @@ export function Tabs(): JSX.Element {
   const tabs = useMemo(
     () =>
       navigationMap.map(({ label, route }, index) => {
-        const notifyIcon = label === 'Notification' && unreadNotificaitons > 0;
+        const notifyIcon =
+          label === 'Notification' && unreadNotificationsCount > 0;
 
         return {
           id: index.toString(),
@@ -52,7 +46,7 @@ export function Tabs(): JSX.Element {
                     {notifyIcon && (
                       <Badge
                         color="secondary"
-                        badgeContent={unreadNotificaitons}
+                        badgeContent={unreadNotificationsCount}
                         overlap="rectangular"
                       >
                         <NotificationImportantIcon color="secondary" />
@@ -66,7 +60,7 @@ export function Tabs(): JSX.Element {
           },
         };
       }),
-    [unreadNotificaitons],
+    [unreadNotificationsCount],
   );
 
   return <HeaderTabs tabs={tabs} selectedIndex={selectedTab} />;

--- a/plugins/parodos/src/components/notification/Notifications.tsx
+++ b/plugins/parodos/src/components/notification/Notifications.tsx
@@ -51,6 +51,9 @@ export const Notification = () => {
   const styles = useStyles();
   const notifications = useStore(state => state.notifications);
   const fetchNotifications = useStore(state => state.fetchNotifications);
+  const unreadNotificationsCount = useStore(
+    state => state.unreadNotificationsCount,
+  );
   const deleteNotification = useStore(state => state.deleteNotifications);
   const setNotificationState = useStore(state => state.setNotificationState);
   const notificationsCount = useStore(state => state.notificationsCount);
@@ -68,6 +71,7 @@ export const Notification = () => {
     });
   }, [
     fetchNotifications,
+    unreadNotificationsCount,
     state.page,
     state.rowsPerPage,
     state.notificationFilter,

--- a/plugins/parodos/src/components/notification/hooks/usePollApi.ts
+++ b/plugins/parodos/src/components/notification/hooks/usePollApi.ts
@@ -5,7 +5,9 @@ import { useEffect } from 'react';
 
 export function usePollApi() {
   const { fetch } = useApi(fetchApiRef);
-  const fetchNotifications = useStore(state => state.fetchNotifications);
+  const fetchUnreadNotificationsCount = useStore(
+    state => state.fetchUnreadNotificationsCount,
+  );
   const pollingInterval = useStore(state => state.pollingInterval);
   const initialized = useStore(state => state.initialized());
   const notificationsError = useStore(state => state.notificationsError);
@@ -34,12 +36,7 @@ export function usePollApi() {
       return;
     }
 
-    fetchNotifications({
-      filter: 'ALL',
-      page: 0,
-      rowsPerPage: 50,
-      fetch,
-    });
+    fetchUnreadNotificationsCount(fetch);
 
     fetchProjects(fetch);
   }, pollingInterval);

--- a/plugins/parodos/src/stores/types.ts
+++ b/plugins/parodos/src/stores/types.ts
@@ -54,6 +54,8 @@ export type NotificationOperation = 'READ' | 'ARCHIVE' | 'UNARCHIVE';
 export interface NotificationsSlice {
   notifications: Map<string, NotificationContent>;
   notificationsCount: number;
+  unreadNotificationsCount: number;
+  fetchUnreadNotificationsCount(fetch: FetchApi['fetch']): Promise<void>;
   fetchNotifications(params: {
     fetch: FetchApi['fetch'];
     filter: NotificationState;


### PR DESCRIPTION
Split fetching notifications into two methods:
- Fetch notifications per page with filter options for showing them in notifications page
- Poll unread notifications total count for showing badge count on navigation tabs