### PR TITLE
add desc to sort querystring for notifications

### DIFF
--- a/plugins/parodos/src/stores/slices/notificationsSlice.ts
+++ b/plugins/parodos/src/stores/slices/notificationsSlice.ts
@@ -9,7 +9,7 @@ async function fetchNotifications(
   options: Parameters<NotificationsSlice['fetchNotifications']>[0],
 ) {
   const { filter, page, rowsPerPage, fetch } = options;
-  let urlQuery = `?page=${page}&size=${rowsPerPage}&sort=notificationMessage.createdOn,notificationMessage.subject`;
+  let urlQuery = `?page=${page}&size=${rowsPerPage}&sort=notificationMessage.createdOn,desc`;
   if (filter !== 'ALL') {
     urlQuery += `&state=${filter}`;
   }


### PR DESCRIPTION
notifications are sorting by date ascending meaning new notifications come in last.

This PR adds `desc` to the querystring