### PR TITLE
change format url to format uri and widen validation

### DIFF
--- a/plugins/parodos/src/components/Form/Form.test.tsx
+++ b/plugins/parodos/src/components/Form/Form.test.tsx
@@ -42,6 +42,46 @@ describe('<Form />', () => {
 
       expect(onSubmit).toHaveBeenCalled();
     });
+
+    it('can submit the form with ssh url', async () => {
+      const onSubmit = jest.fn();
+
+      const { getByRole } = render(
+        <Form formSchema={formSchema} onSubmit={onSubmit} />,
+      );
+
+      await fireEvent.change(getByRole('textbox', { name: 'api-server' }), {
+        target: {
+          value: 'ssh://git@bitbucket.org:Example-org/spring-world.git',
+        },
+      });
+
+      await act(async () => {
+        await fireEvent.click(getByRole('button', { name: 'NEXT' }));
+      });
+
+      expect(onSubmit).toHaveBeenCalled();
+    });
+
+    it('cannot submit the form with invalid git url', async () => {
+      const onSubmit = jest.fn();
+
+      const { getByRole } = render(
+        <Form formSchema={formSchema} onSubmit={onSubmit} />,
+      );
+
+      await fireEvent.change(getByRole('textbox', { name: 'api-server' }), {
+        target: {
+          value: 'gitaaa@bitbucket.org:Example-org/spring-world.git',
+        },
+      });
+
+      await act(async () => {
+        await fireEvent.click(getByRole('button', { name: 'NEXT' }));
+      });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
   });
 
   describe('with stepper', () => {

--- a/plugins/parodos/src/components/workflow/onboarding/Onboarding.tsx
+++ b/plugins/parodos/src/components/workflow/onboarding/Onboarding.tsx
@@ -95,7 +95,7 @@ export function Onboarding({ isNew }: OnboardingProps): JSX.Element {
             transformErrors={(errors: RJSFValidationError[]) => {
               return errors.map(err =>
                 err?.message?.includes('must match pattern')
-                  ? { ...err, message: 'invalid url' }
+                  ? { ...err, message: 'invalid uri' }
                   : err,
               );
             }}

--- a/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema/jsonSchemaFromWorkflowDefinition.ts
+++ b/plugins/parodos/src/hooks/useWorkflowDefinitionToJsonSchema/jsonSchemaFromWorkflowDefinition.ts
@@ -34,10 +34,11 @@ export function getJsonSchemaType(
         type: 'string',
         format: 'email',
       };
-    case 'url':
+    case 'uri':
       return {
         type: 'string',
-        pattern: '^(https?)://', // TODO: better regex
+        pattern:
+          '^(https://www.|https://|git@|ssh://[a-z]+@)?[a-zA-Z0-9]+([-.]{1}[a-zA-Z0-9]+)*.[:a-zA-Z-0-9]+(:[0-9]{1,5})?(/.*)?$',
       };
     case 'boolean': {
       return {
@@ -92,7 +93,7 @@ export function getUiSchema(type: ParameterFormat) {
       return {
         'ui:widget': 'checkboxes',
       };
-    case 'url':
+    case 'uri':
     case 'number':
       return {};
     default:

--- a/plugins/parodos/src/hooks/workflowsPayload.test.ts
+++ b/plugins/parodos/src/hooks/workflowsPayload.test.ts
@@ -18,7 +18,7 @@ describe('getWorkflowsPayload', () => {
           description: 'The project url',
           required: false,
           type: 'string',
-          format: 'url',
+          format: 'uri',
         },
         workloadId: {
           description: 'The workload id',

--- a/plugins/parodos/src/mocks/workflowDefinitions/andromeda.ts
+++ b/plugins/parodos/src/mocks/workflowDefinitions/andromeda.ts
@@ -20,7 +20,7 @@ export const mockAndromedaWorkflowDefinition: WorkflowDefinition = {
           description: 'The api server',
           required: false,
           type: 'string',
-          format: 'url',
+          format: 'uri',
         },
       },
       workType: 'TASK',
@@ -54,7 +54,7 @@ export const mockWorkflowParams: Record<string, WorkFlowTaskParameter> = {
     description: 'An URL parameter',
     required: true,
     type: 'string',
-    format: 'url',
+    format: 'uri',
   },
   param3: {
     description: 'Date parameter type.',

--- a/plugins/parodos/src/mocks/workflowDefinitions/deepRecursiveWorks.ts
+++ b/plugins/parodos/src/mocks/workflowDefinitions/deepRecursiveWorks.ts
@@ -15,7 +15,7 @@ export const mockDeepRecursiveWorks: WorkflowDefinition = {
       workType: 'TASK',
       parameters: {
         domainName: {
-          format: 'url',
+          format: 'uri',
           description: 'The domain name',
           type: 'string',
           required: true,

--- a/plugins/parodos/src/mocks/workflowDefinitions/dependant.ts
+++ b/plugins/parodos/src/mocks/workflowDefinitions/dependant.ts
@@ -10,7 +10,7 @@ export const mockDependantDefinition: WorkflowDefinition = {
   modifyDate: '2023-05-02T09:53:35.450+00:00',
   parameters: {
     projectUrl: {
-      format: 'url',
+      format: 'uri',
       description: 'The project url',
       type: 'string',
       required: false,
@@ -55,7 +55,7 @@ export const mockDependantDefinition: WorkflowDefinition = {
           workType: 'TASK',
           parameters: {
             domainName: {
-              format: 'url',
+              format: 'uri',
               description: 'The domain name',
               type: 'string',
               required: true,
@@ -166,7 +166,7 @@ export const mockDependantDefinition: WorkflowDefinition = {
           workType: 'TASK',
           parameters: {
             hostname: {
-              format: 'url',
+              format: 'uri',
               description: 'The hostname',
               type: 'string',
               required: true,

--- a/plugins/parodos/src/models/workflowDefinitionSchema.ts
+++ b/plugins/parodos/src/models/workflowDefinitionSchema.ts
@@ -12,7 +12,7 @@ const parameterFormat = z.union([
   z.literal('email'),
   z.literal('date'),
   z.literal('number'),
-  z.literal('url'),
+  z.literal('uri'),
   z.literal('boolean'),
   z.literal('select'),
   z.literal('multi-select'),


### PR DESCRIPTION
We want to support `ssh` and `git` urls in the form validation.

e.g. 

```
ssh://git@bitbucket.org:Example-org/spring-world.git
git@bitbucket.org:Example-org/spring-world.git
```

This is the regex to [validate this](https://regex101.com/r/Ds9GWb/1).