### PR TITLE
two topology fixes

### DIFF
--- a/plugins/parodos/src/components/workflow/Assessment/AssessmentWorkflowExecution.tsx
+++ b/plugins/parodos/src/components/workflow/Assessment/AssessmentWorkflowExecution.tsx
@@ -118,7 +118,7 @@ export function AssessmentWorkflowExecution(): JSX.Element {
           <Typography>Assessment results</Typography>
         </Breadcrumbs>
       </Box>
-      <InfoCard className={commonStyles.fullHeight}>
+      <InfoCard className={commonStyles.svgCard}>
         <WorkflowExplorer
           setWorkflowName={setWorkflowName}
           executionId={assessmentWorkflowExecutionId}

--- a/plugins/parodos/src/components/workflow/hooks/useUpdateWorks.ts
+++ b/plugins/parodos/src/components/workflow/hooks/useUpdateWorks.ts
@@ -73,7 +73,6 @@ export function useUpdateWorks({ executionId }: UpdateWorks): {
 
       if (workflowStatus === 'FAILED') {
         setWorkflowError(new Error(`workflow failed`));
-        return [];
       }
 
       if (response.works.some(w => w.status === 'REJECTED')) {
@@ -82,7 +81,6 @@ export function useUpdateWorks({ executionId }: UpdateWorks): {
             `A workflow task has been rejected.  Please check the logs for this task.`,
           ),
         );
-        return [];
       }
 
       const workflow = getWorkDefinitionBy('byName', response.workFlowName);

--- a/plugins/parodos/src/components/workflow/workflowDetail/WorkFlowDetail.tsx
+++ b/plugins/parodos/src/components/workflow/workflowDetail/WorkFlowDetail.tsx
@@ -12,6 +12,7 @@ import { assert } from 'assert-ts';
 import { AssessmentBreadCrumb } from '../../AssessmentBreadCrumb/AssessmentBreadCrumb';
 import { useSearchParams } from 'react-router-dom';
 import { WorkflowExplorer } from './WorkflowExplorer';
+import { useCommonStyles } from '../../../styles';
 
 const useStyles = makeStyles(_theme => ({
   container: {
@@ -22,12 +23,10 @@ const useStyles = makeStyles(_theme => ({
   badge: {
     alignSelf: 'flex-start',
   },
-  card: {
-    height: '100%',
-  },
 }));
 
 export function WorkFlowDetail(): JSX.Element {
+  const commonStyles = useCommonStyles();
   const { projectId, executionId } = useParams();
   assert(!!projectId, 'no projectId param');
   assert(!!executionId, 'no executionId param');
@@ -62,7 +61,7 @@ export function WorkFlowDetail(): JSX.Element {
           />
         </Box>
       )}
-      <InfoCard className={styles.card}>
+      <InfoCard className={commonStyles.svgCard}>
         <Typography paragraph>
           Please provide additional information related to your project.
         </Typography>

--- a/plugins/parodos/src/components/workflow/workflowDetail/WorkflowExplorer.tsx
+++ b/plugins/parodos/src/components/workflow/workflowDetail/WorkflowExplorer.tsx
@@ -11,6 +11,7 @@ import { useUpdateLogs } from '../hooks/useUpdateLogs';
 import { useUpdateWorks } from '../hooks/useUpdateWorks';
 import { WorkFlowStepper } from './topology/WorkFlowStepper';
 import { WorkFlowLogViewer } from './WorkFlowLogViewer';
+import cs from 'classnames';
 
 interface WorkflowExplorerProps {
   executionId: string;
@@ -22,8 +23,13 @@ const useStyles = makeStyles(_theme => ({
   detailContainer: {
     flex: 1,
     display: 'grid',
-    gridTemplateRows: '1fr auto 1fr',
     minHeight: 0,
+  },
+  twoRow: {
+    gridTemplateRows: '2fr 1fr',
+  },
+  threeRow: {
+    gridTemplateRows: '1fr auto 1fr',
   },
   viewerContainer: {
     display: 'grid',
@@ -49,13 +55,18 @@ export function WorkflowExplorer({
   }, [setWorkflowName, workflowName]);
 
   return (
-    <Box className={styles.detailContainer}>
+    <Box
+      className={cs(styles.detailContainer, {
+        [styles.threeRow]: !!children,
+        [styles.twoRow]: !children,
+      })}
+    >
       {tasks.length > 0 ? (
         <WorkFlowStepper tasks={tasks} setSelectedTask={setSelectedTask} />
       ) : (
         <Progress />
       )}
-      <div>{children}</div>
+      {children && <div>{children}</div>}
       <div className={styles.viewerContainer}>
         {log !== '' && <WorkFlowLogViewer log={log} />}
       </div>

--- a/plugins/parodos/src/components/workflow/workflowDetail/topology/PipelineLayout.tsx
+++ b/plugins/parodos/src/components/workflow/workflowDetail/topology/PipelineLayout.tsx
@@ -26,6 +26,7 @@ import { useParentSize } from '@cutting/use-get-parent-size';
 import { FirstTaskId } from '../../../../hooks/getWorkflowDefinitions';
 import { useWorkflowContext } from '../WorkflowContext';
 import { WorkflowAlert } from './WorkflowAlert';
+import { makeStyles } from '@material-ui/core';
 
 export const PIPELINE_NODE_SEPARATION_VERTICAL = 10;
 
@@ -36,7 +37,14 @@ type Props = {
   setSelectedTask: (selectedTask: string) => void;
 };
 
+const useStyles = makeStyles(_theme => ({
+  container: {
+    height: '100%',
+  },
+}));
+
 const TopologyPipelineLayout = ({ tasks, setSelectedTask }: Props) => {
+  const styles = useStyles();
   const { workflowMode, showAlert, clearAlert } = useWorkflowContext();
   const [selectedIds, setSelectedIds] = useState<string[]>();
   const pipelineNodes = useDemoPipelineNodes(tasks);
@@ -118,7 +126,7 @@ const TopologyPipelineLayout = ({ tasks, setSelectedTask }: Props) => {
   return (
     <>
       {alertTask && <WorkflowAlert task={alertTask} />}
-      <div ref={containerRef}>
+      <div className={styles.container} ref={containerRef}>
         <TopologyView>
           <VisualizationSurface state={{ selectedIds }} />
         </TopologyView>

--- a/plugins/parodos/src/styles.tsx
+++ b/plugins/parodos/src/styles.tsx
@@ -25,4 +25,11 @@ export const useCommonStyles = makeStyles(theme => ({
   link: {
     color: theme.palette.primary.main,
   },
+  svgCard: {
+    height: '100%',
+    '& div[class^="MuiCardContent-root"]': {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+  },
 }));


### PR DESCRIPTION
1.  Apply height: `100%` to all immediate parents of the topology svg or the svg will not claim all available height.
2. I introduced a bug when I split out the `useUpdateWorks` hook that meant errors where not getting displayed when the workflow failed.