### PR TITLE
Group restarted workflows

### DIFF
--- a/plugins/parodos/src/components/workflow/workflowDetail/WorkflowExplorer.tsx
+++ b/plugins/parodos/src/components/workflow/workflowDetail/WorkflowExplorer.tsx
@@ -53,11 +53,13 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
   },
   alertContainer: {
     margin: theme.spacing(3),
-    width: '66%',
-    maxWidth: 'inherit',
+    width: '100%',
     flexWrap: 'nowrap',
     color: theme.palette.banner.text,
     backgroundColor: theme.palette.status.error,
+    [theme.breakpoints.up('lg')]: {
+      width: '66%',
+    },
   },
   restartConfirmation: {
     display: 'flex',

--- a/plugins/parodos/src/models/workflowTaskSchema.ts
+++ b/plugins/parodos/src/models/workflowTaskSchema.ts
@@ -70,6 +70,7 @@ export const projectWorkflowSchema = z.object({
   startDate: z.string(),
   endDate: z.string().optional(),
   executeBy: z.string(),
+  originalExecutionId: z.string().optional().nullable(),
   additionalInfos: z.array(additionalInfoSchema).optional().nullable(),
 });
 


### PR DESCRIPTION
I tried to do expand/hide restarted workflows with animation, but doesn't work well. It's impossible to use `<Collaplse />` component in table row, for example, because of html errors. Another solution was to use nested tables, but for some reason a nested table had different column widths even if I used the same widths from parent table and overall width of nested table is the same as parent table.
<img width="1852" alt="Screenshot 2023-07-27 at 16 10 52" src="https://github.com/parodos-dev/backstage-parodos/assets/6397708/aa963f78-02b6-4cb1-921a-c46fdbd7ea76">

